### PR TITLE
2 remove archived repos from config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.egg-info
 *.pyc
 *pycache*
+venv/

--- a/kwalitee/config.yml
+++ b/kwalitee/config.yml
@@ -16,8 +16,6 @@ repolist:
     compliant_cli: true
   - url: https://github.com/OCR-D/ocrd_kraken
     compliant_cli: false
-  - url: https://github.com/OCR-D/ocrd_ocropy
-    compliant_cli: true
   - url: https://github.com/OCR-D/ocrd_olena
     compliant_cli: true
   - url: https://github.com/OCR-D/ocrd_segment
@@ -30,11 +28,7 @@ repolist:
   - url: https://github.com/OCR-D/ocrd_anybaseocr
     official: true
     compliant_cli: false
-  - url: https://github.com/ocr-d-modul-2-segmentierung/ocrd_pc_segmentation
-    official: true
-    compliant_cli: true
   - url: https://github.com/qurator-spk/dinglehopper
-  # - url: https://github.com/qurator-spk/pixelwise_segmentation_SBB
   - url: https://github.com/OCR-D/ocrd_typegroups_classifier
     official: true
     compliant_cli: true


### PR DESCRIPTION
This PR removes two repositories from the `config.yml`.

- `ocrd-ocropy` is archived and no longer in use, therefore not relevant anymore
- `ocrd_pc_segmentation` is not available at all; trying to reach the repo results in a `404`

I also removed some dead code in the config.