### PR TITLE
feat: add JSON schemas

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,16 @@ The webapp is available over at the [OCR-D website](https://ocr-d.de/kwalitee/).
 
 The scheduled pipeline of this repo updates the `repos.json` file every night which serves as data for the webapp.
 
+## JSON Validation
+
+In order to validate the resulting JSON files, use
+
+```bash
+python3 schema/validation.py {FILENAME}
+```
+
+with `{FILENAME}` being either `repos.json` or `ocrd_all_releases.json`, depending on which one you'd like to validate.
+
 ## Contributing
 
 Pull requests are welcome. For major changes, please open an issue first to discuss what you would like to change.

--- a/schema/ocrd_all_releases.json
+++ b/schema/ocrd_all_releases.json
@@ -1,0 +1,18 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://ocr-d.de/ocrd_all_releases.schema.json",
+    "title": "Release Information",
+    "description": "Information needed on releases for the OCR-D Kwalitee Dashboard",
+    "type": "object",
+    "properties": {
+        "tag": {
+            "type": "string",
+            "pattern": "^v[0-9]{4}(-[0-9]{2}){2}$"
+        },
+        "projects": {
+            "type": "array",
+            "uniqueItems": true,
+            "minItems": 1
+        }
+    }
+}

--- a/schema/repos.json
+++ b/schema/repos.json
@@ -1,0 +1,65 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://ocr-d.de/repos.schema.json",
+    "title": "Repository Information",
+    "description": "Information needed on projects for the OCR-D Kwalitee Dashboard",
+    "type": "object",
+    "properties":{
+        "additional_info": {
+            "description": "A section for more information about the project.",
+            "links": {
+                "description": "Links to important files on GitHub (if available).",
+                "type": "object",
+                "properties": {
+                    "Dockerfile": {
+                        "type": "string",
+                        "pattern": "(^https:\/\/github.com(\/[a-zA-Z0-9_-]+)+\/blob\/master\/Dockerfile$|)"
+                    },
+                    "README.md": {
+                        "type": "string",
+                        "pattern": "(^https:\/\/github.com(\/[a-zA-Z0-9_-]+)+\/blob\/master\/README.md$|)"
+                    },
+                    "ocrd-tool.json": {
+                        "type": "string",
+                        "pattern": "(^https:\/\/github.com(\/[a-zA-Z0-9_-]+)+\/blob\/master\/ocrd-tool.json$|)"
+                    },
+                    "setup.py": {
+                        "type": "string",
+                        "pattern": "(^https:\/\/github.com(\/[a-zA-Z0-9_-]+)+\/blob\/master\/setup.py$|)"
+                    }
+                }
+            }
+        },
+        "compliant_cli": {
+            "description": "Whether the CLI of the project complies to the OCR-D CLI specification.",
+            "type": "boolean"
+        },
+        "id": {
+            "description": "A unique identifier of the project. Equals the project name.",
+            "type": "string"
+        },
+        "latest_version": {
+            "description": "The latest tag of the project known to GitHub.",
+            "type": "string",
+            "pattern": "(^v?[0-9]+.[0-9]+.*?$)|"
+        },
+        "ocrd_tool_json_valid": {
+            "description": "Whether the ocrd-tool.json is valid according to the OCR-D specification.",
+            "type": "boolean"
+        },
+        "official": {
+            "description": "Whether the project is officially maintained by the OCR-D coordination project.",
+            "type": "boolean"
+        },
+        "project_type": {
+            "description": "Denotes the language in which the project has been implemented. Equals 'bashlib' or 'python'.",
+            "type": "string",
+            "pattern": "(bashlib|python)"
+        },
+        "url": {
+            "description": "The GitHub URL of the project.",
+            "type": "string",
+            "pattern": "^https://github.com(/[a-zA-Z0-9-_]+)+$"
+        }
+    }
+}

--- a/schema/validation.py
+++ b/schema/validation.py
@@ -1,0 +1,28 @@
+from jsonschema import validate
+import json
+import os
+import sys
+
+
+def load_json(filename):
+    with open(filename) as jsonfile:
+        data = json.load(jsonfile)
+        return data
+
+def load_schema(filename):
+    with open('schema/' + filename) as jsonfile:
+        data = json.load(jsonfile)
+        return data
+
+file_to_validate = sys.argv[1]
+
+if os.path.isfile(file_to_validate) == False:
+    print(f"--- File not found: {file_to_validate}\n--- Usage: ./schema/validation.py FILENAME\n--- Example: ./schema/validation.py repos.json")
+    raise Exception("File not found.")
+
+
+schema = load_schema(file_to_validate)
+instance = load_json(file_to_validate)
+
+for object in instance:
+    validate(instance=object, schema=schema)


### PR DESCRIPTION
This PR adds JSON schemas for `repos.json` and `ocrd_all_releases.py` to the repository, incl. a validation script. The latter can be invoked by

```bash
python3 schema/validation.py {FILENAME}
```

with `{FILENAME}` being either `repos.json` or `ocrd_all_releases.json`, depending on which one you'd like to validate.

Closes #13.