### PR TITLE
19 fix ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ jobs:
           name: Update submodules
           command: |
             . venv/bin/activate
-            git submodule update --init --recurse
+            git submodule update --init --recursive
       - save_cache:
           key: deps1-{{ .Branch }}-submodules
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,8 +20,12 @@ jobs:
           command: |
             . venv/bin/activate
             git submodule update --init
+<<<<<<< Updated upstream
 #            git submodule foreach --recursive git fetch
             git submodule foreach --recursive 'git pull origin $(git symbolic-ref --short refs/remotes/origin/HEAD | cut -d'/' -f2)'
+=======
+            git submodule foreach --recursive 'git update --init --remote' || exit 0
+>>>>>>> Stashed changes
       - save_cache:
           key: deps1-{{ .Branch }}-submodules
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,9 @@ jobs:
           name: Update submodules
           command: |
             . venv/bin/activate
-            git submodule update --init --recursive
+            git submodule update --init
+            git submodule foreach --recursive git fetch
+            git submodule foreach git merge origin master
       - save_cache:
           key: deps1-{{ .Branch }}-submodules
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,12 +20,7 @@ jobs:
           command: |
             . venv/bin/activate
             git submodule update --init
-<<<<<<< Updated upstream
-#            git submodule foreach --recursive git fetch
-            git submodule foreach --recursive 'git pull origin $(git symbolic-ref --short refs/remotes/origin/HEAD | cut -d'/' -f2)'
-=======
             git submodule foreach --recursive 'git update --init --remote' || exit 0
->>>>>>> Stashed changes
       - save_cache:
           key: deps1-{{ .Branch }}-submodules
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ jobs:
             . venv/bin/activate
             git submodule update --init
             git submodule foreach --recursive git fetch
-            git submodule foreach git merge origin master
+            git submodule foreach --recursive 'git pull origin $(git symbolic-ref --short refs/remotes/origin/HEAD | cut -d'/' -f2)'
       - save_cache:
           key: deps1-{{ .Branch }}-submodules
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ jobs:
           command: |
             . venv/bin/activate
             git submodule update --init
-            git submodule foreach --recursive 'git update --init --remote' || exit 0
+            git submodule foreach --recursive 'git submodule update --init --remote' || exit 0
       - save_cache:
           key: deps1-{{ .Branch }}-submodules
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ jobs:
           command: |
             . venv/bin/activate
             git submodule update --init
-            git submodule foreach --recursive git fetch
+#            git submodule foreach --recursive git fetch
             git submodule foreach --recursive 'git pull origin $(git symbolic-ref --short refs/remotes/origin/HEAD | cut -d'/' -f2)'
       - save_cache:
           key: deps1-{{ .Branch }}-submodules

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ jobs:
           name: Update submodules
           command: |
             . venv/bin/activate
-            git submodule update --init
+            git submodule update --init --recurse
       - save_cache:
           key: deps1-{{ .Branch }}-submodules
           paths:


### PR DESCRIPTION
This PR implements cloning of all of `ocrd_all`'s submodules which is necessary for the creation of `repos.json`.

It consists of the somewhat strange line

```
git submodule foreach --recursive 'git submodule update --init --remote' || exit 0
```
which causes the step to be always successful. This is necessary because `git submodule update --init --recursive` interferes with the private submodules in `cor-asv-ann` and `git submodule update --init --remote` cannot handle `eynollah`'s default branch `main` (instead of `master`). The necessary info for the creation of `repos.json` is present, though.

Closes #19.