### PR TITLE
Fix ocrd tool json

### DIFF
--- a/kwalitee/cli.py
+++ b/kwalitee/cli.py
@@ -96,24 +96,6 @@ def generate_json(ctx, output=None):
         print(json_str)
 
 
-@repo.command('ocrd-tool')
-@click.option('-o', '--output', help="Output file. Omit to print to STDOUT")
-@pass_ctx
-def generate_tool_json(ctx, output=None):
-    '''
-    Return one big list of ocrd tools
-    '''
-    ret = {}
-    _check_cloned(ctx)
-    for repo in ctx.repos:
-        ret = {**ret, **repo.get_ocrd_tools()}
-    json_str = json.dumps(ret, indent=4, sort_keys=True)
-    if output:
-        Path(output).write_text(json_str)
-    else:
-        print(json_str)
-
-
 @cli.command("validate", help="Validate created JSON files")
 @click.option('-f', '--file',
     type=click.Choice(['repos.json', 'ocrd_all_releases.json']),
@@ -130,7 +112,6 @@ def json_validate(file):
         schema = json.load(s)
 
     _inform_of_result(JsonValidator.validate(instance, schema))
-    
 
 def _inform_of_result(report):
     if not report.is_valid:

--- a/kwalitee/repo.py
+++ b/kwalitee/repo.py
@@ -26,6 +26,7 @@ class Repo():
         self.dependencies = self.get_dependencies()
         self.dependency_conflicts = self.get_dependency_conflicts()
         self.unreleased_changes = self.get_unreleased_changes()
+        self.org_plus_name = '/'.join(self.url.split('/')[-2:])
 
     def __str__(self):
         return '<Repo %s @ %s>' % (self.url, self.path)

--- a/kwalitee/repo.py
+++ b/kwalitee/repo.py
@@ -1,12 +1,13 @@
 import json
+import re
 from pathlib import Path
-from subprocess import run, PIPE
 from shlex import split as X
-from ocrd_utils import pushd_popd, getLogger
-import re
-from ocrd_validators import OcrdToolValidator
+from subprocess import PIPE, run
+
 import requests
-import re
+from ocrd_utils import getLogger, pushd_popd
+from ocrd_validators import OcrdToolValidator
+
 
 class Repo():
 


### PR DESCRIPTION
This PR removes the broken CLI option `repo ocrd-tool`. We had removed the called function some time ago since we decided to directly link to the ocrd-tool.json files but missed updating the CLI.

This PR also includes a little fix for a missing property of the Repo class.