### PR TITLE
Fix ocrd tool json

### DIFF
--- a/kwalitee/cli.py
+++ b/kwalitee/cli.py
@@ -96,6 +96,24 @@ def generate_json(ctx, output=None):
         print(json_str)
 
 
+@repo.command('ocrd-tool')
+@click.option('-o', '--output', help="Output file. Omit to print to STDOUT")
+@pass_ctx
+def generate_tool_json(ctx, output=None):
+    '''
+    Return one big list of ocrd tools
+    '''
+    ret = {}
+    _check_cloned(ctx)
+    for repo in ctx.repos:
+        ret = {**ret, **repo.get_ocrd_tools()}
+    json_str = json.dumps(ret, indent=4, sort_keys=True)
+    if output:
+        Path(output).write_text(json_str)
+    else:
+        print(json_str)
+
+
 @cli.command("validate", help="Validate created JSON files")
 @click.option('-f', '--file',
     type=click.Choice(['repos.json', 'ocrd_all_releases.json']),
@@ -112,6 +130,7 @@ def json_validate(file):
         schema = json.load(s)
 
     _inform_of_result(JsonValidator.validate(instance, schema))
+    
 
 def _inform_of_result(report):
     if not report.is_valid:

--- a/kwalitee/repo.py
+++ b/kwalitee/repo.py
@@ -28,6 +28,7 @@ class Repo():
         self.dependency_conflicts = self.get_dependency_conflicts()
         self.unreleased_changes = self.get_unreleased_changes()
         self.org_plus_name = '/'.join(self.url.split('/')[-2:])
+        self.ocrd_tool = self.get_ocrd_tool()
 
     def __str__(self):
         return '<Repo %s @ %s>' % (self.url, self.path)
@@ -81,14 +82,11 @@ class Repo():
 
     def validate_ocrd_tool_json(self):
         valid = False
-        with pushd_popd(self.path):
-            if Path('ocrd-tool.json').is_file():
-                with open('ocrd-tool.json', 'r') as f:
-                    tool = json.load(f)
-                    result = OcrdToolValidator.validate(tool)
-                    
-                    if 'OK' in str(result):
-                        valid = True
+        tool = self.get_ocrd_tool()
+        if tool:
+            result = OcrdToolValidator.validate(tool)
+            if 'OK' in str(result):
+                valid = True
         return valid
 
     def get_project_type(self):
@@ -133,6 +131,14 @@ class Repo():
             else:
                 total_no_of_commits = self._run('git rev-list --count HEAD').stdout.strip()
                 return int(total_no_of_commits)
+
+    def get_ocrd_tool(self):
+        result = None
+        with pushd_popd(self.path):
+            if Path('ocrd-tool.json').is_file():
+                with open('ocrd-tool.json', 'r', encoding='utf-8') as f:
+                    result = json.load(f)
+        return result
 
     def _get_latest_tag(self):
         complete_refs = self._run('git show-ref --tag')

--- a/tests/test_repo.py
+++ b/tests/test_repo.py
@@ -122,3 +122,9 @@ def test_dependency_conflict_false():
     repos = get_repos_list()
     repo = get_repo(repos, 'ocrd_typegroups_classifier')
     repo.dependency_conflicts = None
+
+def test_ocrd_tool():
+    repos = get_repos_list()
+    repo = get_repo(repos, 'ocrd_olahd_client')
+    assert repo.ocrd_tool['git_url'] == 'https://github.com/OCR-D/ocrd_olahd_client'
+    


### PR DESCRIPTION
As @kba pointed out, the info about the `ocrd-tool.json` is still relevant in some cases (see https://github.com/OCR-D/kwalitee-dashboard-back-end/pull/30#discussion_r972011212). This PR re-introduces the functionality to the `Repo` class.